### PR TITLE
Unary offset

### DIFF
--- a/a86/ast.rkt
+++ b/a86/ast.rkt
@@ -211,6 +211,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Offsets
 
+(provide Offset Offset?)
+
 (define check:offset
   (λ (m n)
     (unless (exp? m)

--- a/a86/ast.rkt
+++ b/a86/ast.rkt
@@ -503,6 +503,8 @@
   (match i
     [(Label _) '()]  ; declaration, not use
     [(Extern _) '()] ; declaration, not use
+    [(Offset m)
+     (label-uses m)]
     [(instruction _)
      (append-map label-uses (instruction-args i))]
     [($ x) (list x)]


### PR DESCRIPTION
Overload Offset to take either 1 or 2 arguments to be backwards compatible.
`(Offset 'rax 0)` turns into `(Offset (Plus 'rax 0))`.