### PR TITLE
Fix clang version detection

### DIFF
--- a/a86/check-assembler.rkt
+++ b/a86/check-assembler.rkt
@@ -38,7 +38,7 @@ HERE
 (define (clang-version-string)
   (parameterize ([current-output-port (open-output-string)]
                  [current-error-port (open-output-string)])
-    (and (system (format "~aclang -v 2>&1"
+    (and (system (format "~aclang --version 2>&1"
                          (if (macos?)
                              "arch -x86_64 "
                              "")))


### PR DESCRIPTION
Hi. In some configurations, "clang -v" will exit with a nonzero status (https://github.com/llvm/llvm-project/issues/67209). This leads to version detection not working despite clang being installed:
```
sh-5.3$ clang -v 2>&1
clang version 20.1.8
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm/20/bin
Configuration file: /etc/clang/20/x86_64-pc-linux-gnu-clang.cfg
System configuration file directory: /etc/clang/20
User configuration file directory: /home/jakub/.config/clang
Selected GCC installation: /usr/lib/gcc/x86_64-pc-linux-gnu/14
Candidate multilib: .;@m64
Selected multilib: .;@m64
 "/usr/bin/x86_64-pc-linux-gnu-ld.bfd" --hash-style=gnu --eh-frame-hdr -m elf_x86_64 -pie -dynamic-linker /lib64/ld-linux-x86-64.so.2 -o a.out /usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../lib64/Scrt1.o /usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../lib64/crti.o /usr/lib/gcc/x86_64-pc-linux-gnu/14/crtbeginS.o -L/usr/lib/gcc/x86_64-pc-linux-gnu/14 -L/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../lib64 -L/lib/../lib64 -L/usr/lib/../lib64 -L/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/lib -L/lib -L/usr/lib -z relro -z now -lgcc --as-needed -lgcc_s --no-as-needed -lc -lgcc --as-needed -lgcc_s --no-as-needed /usr/lib/gcc/x86_64-pc-linux-gnu/14/crtendS.o /usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../lib64/crtn.o
/usr/bin/x86_64-pc-linux-gnu-ld.bfd: /usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../lib64/Scrt1.o: in function `_start':
(.text+0x1b): undefined reference to `main'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
sh-5.3$ echo $?
1
sh-5.3$ racket -e '(require "a86/check-assembler.rkt") (check-clang-available)'
clang not found: either you have not installed clang
or it cannot be found in your PATH: /home/jakub/.config/guix/current/bin:/home/jakub/.config/guix/current/bin:/home/jakub/.config/guix/current/bin:/home/jakub/.nix-profile/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin:/usr/lib/llvm/20/bin:/usr/lib/llvm/19/bin:/etc/eselect/wine/bin:/home/jakub/.local/bin:/home/jakub/.local/share/go/bin.
  context...:
   body of top-level
```

As suggested in the linked issue, we could simply use "--version" since we are only after the version string.
```
sh-5.3$ clang --version 2>&1
clang version 20.1.8
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm/20/bin
Configuration file: /etc/clang/20/x86_64-pc-linux-gnu-clang.cfg
sh-5.3$ echo $?
0
```

