### PR TITLE
Remove offending line logic

### DIFF
--- a/a86/interp.rkt
+++ b/a86/interp.rkt
@@ -215,29 +215,8 @@
    "if you did and still get this error; please share with course staff."))
 
 (define (clang:error msg)
-  (raise (exn:clang (format "~a\n\n~a~a" assembly-error-msg msg (assembly-offending-line msg))
+  (raise (exn:clang (format "~a\n\n~a" assembly-error-msg msg)
                     (current-continuation-marks))))
-
-(define (assembly-offending-line msg)
-  (match (regexp-match
-          "(.*):([0-9]+):([0-9]+): error: " msg)
-    [(list _ (app string->path file) (app string->number line) (app string->number offset))
-     (define line-text
-      (with-input-from-file file
-        (thunk
-         (let loop ([l (read-line)]
-                    [i line])
-           (if (= i 1)
-               l
-               (loop (read-line) (sub1 i)))))))
-     (match (regexp-match "[ ]*(.*)" line-text)
-       [(list _ trimmed-line)
-        (format
-         "\noffending line: ~a\n                ~a^"
-         trimmed-line
-         (make-string offset #\space))])]
-    [_ ""]))
-
 
 ;; run clang on t.s to create t.o
 (define (clang t.s t.o)


### PR DESCRIPTION
The offending line logic is redundant with clang since clangs assembler prints it out as part of the error message already.